### PR TITLE
refactor: modernize site styles

### DIFF
--- a/assets/css/bio.css
+++ b/assets/css/bio.css
@@ -11,10 +11,10 @@
 
 html,
 body {
-  color: var(--white-2);
-  background-color: var(--gray-6);
-  font-family: "JetBrains Mono", monospace;
-  line-height: 1.7;
+  color: var(--text-primary);
+  background-color: var(--white-1);
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  line-height: 1.6;
 }
 main {
   margin: 0 auto;
@@ -26,8 +26,6 @@ main {
   font-size: 2rem;
   color: var(--text-primary);
   margin-bottom: 1.5rem;
-  text-shadow: 0 0 12px var(--highlight-color),
-               0 0 8px var(--highlight-color);
   text-align: center;
 }
 
@@ -37,10 +35,10 @@ main {
   align-items: center;
   gap: 2.5rem;
   padding: 2.5rem 1.5rem;
-  background: var(--gray-3);
-  color: var(--white-1);
+  background: var(--white-1);
+  color: var(--text-primary);
   border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0,0,0,.5);
+  box-shadow: 0 1px 4px rgba(0,0,0,0.1);
 }
 
 .bio-profile { text-align: center; }
@@ -49,8 +47,6 @@ main {
   width: 160px;
   height: 160px;
   border-radius: 50%;
-  box-shadow: 0 0 6px var(--highlight-color),
-              0 0 12px var(--highlight-color);
   transition: transform .3s ease-in-out;
 }
 .profile-picture:hover { transform: scale(1.1); }
@@ -59,13 +55,11 @@ main {
   margin-top: 1rem;
   font-size: 1.6rem;
   color: var(--text-primary);
-  text-shadow: 0 0 6px var(--highlight-color);
 }
 .author-quote {
   margin-top: .5rem;
   font-size: 1rem;
-  color: var(--text-muted);
-  text-shadow: 0 0 6px var(--highlight-color);
+  color: var(--text-secondary);
   font-style: italic;
 }
 
@@ -110,7 +104,6 @@ main {
 }
 .social-link:hover {
   transform: scale(1.2);
-  box-shadow: 0 0 6px var(--highlight-color), 0 0 8px var(--highlight-color);
 }
 .social-icon {
   width: 40px;
@@ -127,11 +120,11 @@ main {
   padding:0;
 }
 .quick-stats li{
-  background:var(--gray-6);
+  background:var(--gray-2);
   padding:.6rem 1.2rem;
   border-radius:6px;
   font-weight:600;
-  box-shadow:0 2px 6px rgba(0,0,0,.35);
+  box-shadow:0 1px 3px rgba(0,0,0,.1);
 }
 
 .section-heading{
@@ -144,16 +137,12 @@ main {
   padding:.45rem 1.6rem;
   font-size:1.55rem;
   color:var(--highlight-color);
-  background:rgba(0,0,0,.25);
-  border:2px solid var(--highlight-color);
-  border-radius:9999px;
-  box-shadow:0 0 10px rgba(0,0,0,.4), 0 0 8px var(--highlight-color);
-  text-shadow:none;
+  border-bottom:2px solid var(--highlight-color);
 }
 
 .timeline{
   list-style:none;
-  border-left:2px dashed var(--gray-1);
+  border-left:2px dashed var(--gray-3);
   padding-left:1.25rem;
   margin:0 auto;
   max-width:640px;
@@ -173,20 +162,20 @@ main {
 }
 .timeline-content h4 {
   font-size:1rem;
-  color:var(--white-1);
+  color:var(--text-primary);
 }
 .timeline-content p {
   font-size:.85rem;
 }
-.edu-meta{ 
+.edu-meta{
   font-size:.9rem;
-  color:var(--white-2);
+  color:var(--text-secondary);
   margin:.25rem 0 .5rem;
 }
 .edu-desc{
   font-size:.9rem;
   margin:.3rem 0 .4rem;
-  color:var(--white-2);
+  color:var(--text-secondary);
 }
 .edu-degree{
   font-size:.9rem;
@@ -198,7 +187,7 @@ main {
   margin-top:.5rem;
   font-size:.85rem;
   line-height:1.45;
-  color:var(--white-1);
+  color:var(--text-secondary);
 }
 
 .chip-heading{ 
@@ -217,7 +206,7 @@ main {
 .chip-tooltip{
   opacity:0;
   visibility:hidden;
-  color:var(--white-1);
+  color:var(--text-primary);
   min-width:190px;
   max-width:280px;
   white-space:normal;
@@ -230,8 +219,8 @@ main {
   font-size:.8rem;
   line-height:1.4;
   transition:.2s;
-  background: var(--gray-4);
-  box-shadow: 0 2px 10px rgba(0,0,0,.45);
+  background: var(--white-1);
+  box-shadow: 0 1px 4px rgba(0,0,0,.1);
 }
 .chip{
   position:relative;

--- a/assets/css/blog.css
+++ b/assets/css/blog.css
@@ -12,10 +12,10 @@
 /* General Layout */
 html,
 body {
-  color: var(--white-2);
-  background-color: var(--gray-6);
-  font-family: "JetBrains Mono", monospace;
-  line-height: 1.7;
+  color: var(--text-primary);
+  background-color: var(--white-1);
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  line-height: 1.6;
 }
 
 /* Main Content Styling */
@@ -72,7 +72,6 @@ img {
   font-size: 2rem;
   color: var(--text-primary);
   margin-bottom: 1.5rem;
-  text-shadow: 0 0 12px var(--highlight-color), 0 0 8px var(--highlight-color);
   text-align: center;
 }
 .articles {
@@ -81,27 +80,26 @@ img {
   margin: 2rem 0 1rem;
 }
 .articles .article {
-  background: var(--gray-3);
-  border: 1px solid var(--text-primary);
+  background: var(--white-1);
+  border: 1px solid var(--gray-3);
   padding: 2rem;
   border-radius: 8px;
-  transition: transform 0.4s cubic-bezier(0.25, 0.8, 0.25, 1), box-shadow 0.4s ease-in-out;
+  transition: box-shadow 0.3s ease;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
 }
 .articles .article:hover {
-  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 }
 .articles .article .article-title {
   color: var(--text-primary);
   font-weight: bold;
   font-size: 1.5rem;
   line-height: 1.3;
-  text-shadow: 0px 0px 4px var(--text-secondary);
   margin-bottom: 0.5rem;
-  transition: color 0.3s, text-shadow 0.3s;
+  transition: color 0.3s;
 }
 .articles .article .article-title:hover {
-  color: var(--highlight-color-retro);
-  text-shadow: 0px 0px 8px var(--highlight-muted-retro);
+  color: var(--highlight-color);
 }
 .article-link {
   color: inherit;
@@ -111,7 +109,7 @@ img {
   display: block;
   font-size: 0.8rem;
   margin-top: 0.5rem;
-  color: var(--white-1);
+  color: var(--text-secondary);
 }
 .articles .article .categories {
   display: flex;
@@ -138,7 +136,7 @@ img {
   margin-top: 1rem;
   font-size: 0.9rem;
   line-height: 1.6;
-  color: var(--white-1);
+  color: var(--text-secondary);
   text-align: justify;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -218,6 +216,5 @@ img {
   }
   .articles .article .article-title {
     font-size: 0.9rem;
-    text-shadow: none;
   }
 }

--- a/assets/css/common.css
+++ b/assets/css/common.css
@@ -1,34 +1,45 @@
+/* Global colour palette */
 :root {
   /* Grayscale */
-  --gray-1: #3f3f3f;
-  --gray-2: #32353a;
-  --gray-3: #25282c;
-  --gray-4: #151618;
-  --gray-5: #151618;
-  --gray-6: #111111;
+  --gray-1: #f8f9fa;
+  --gray-2: #e9ecef;
+  --gray-3: #dee2e6;
+  --gray-4: #ced4da;
+  --gray-5: #adb5bd;
+  --gray-6: #6c757d;
 
   /* Whites */
-  --white-1: #eeeeee;
-  --white-2: #a9abb3;
+  --white-1: #ffffff;
+  --white-2: #f8f9fa;
 
-  /* Highlight and Success */
-  --highlight-color: #348505;
-  --success-color: #348505;
-  --success-muted: #5a8a3c;
+  /* Accent colours */
+  --highlight-color: #0d6efd;
+  --success-color: #198754;
+  --success-muted: #6c757d;
 
-  /* Retro Text Colors */
-  --text-primary: #00ff00; /* Bright green for retro titles */
-  --text-secondary: #33cc33; /* Muted green for secondary text */
-  --text-muted: #66ff66; /* Light green for subtle text */
-  --text-inverted: #000000; /* Black text for light backgrounds */
+  /* Text colours */
+  --text-primary: #212529;
+  --text-secondary: #495057;
+  --text-muted: #6c757d;
+  --text-inverted: #ffffff;
 
-  /* Retro Highlight Colors */
-  --highlight-color-retro: #ff00ff; /* Magenta for retro highlights */
-  --highlight-muted-retro: #cc00cc; /* Muted magenta for hover states */
+  /* Hover variations */
+  --highlight-color-retro: #0b5ed7;
+  --highlight-muted-retro: #0a58ca;
 
-  /* Background Colors for Retro Theme */
-  --bg-primary-retro: #000000; /* Black for retro background */
-  --bg-secondary-retro: #1a1a1a; /* Dark gray for secondary sections */
+  /* Backgrounds */
+  --bg-primary-retro: #ffffff;
+  --bg-secondary-retro: #f8f9fa;
+}
+
+/* Base styles */
+body {
+  margin: 0;
+  background: var(--white-1);
+  color: var(--text-primary);
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
+  line-height: 1.6;
 }
 
 /* Smooth in-page scrolling */
@@ -38,12 +49,10 @@ html {
 
 /* Header Styling */
 .site-header {
-  background-color: var(--gray-5);
+  background-color: var(--white-1);
   padding: 1rem 0;
-  margin: 1rem;
-  border-radius: 12px;
-  box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.3);
-  border: 2px solid var(--text-primary);
+  margin: 0 0 2rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .header-container {
@@ -62,12 +71,10 @@ html {
   color: var(--text-primary);
   text-decoration: none;
   font-weight: bold;
-  text-shadow: 0 0 4px var(--text-secondary), 0 0 8px var(--text-secondary);
-  transition: color 0.3s, text-shadow 0.3s;
+  transition: color 0.3s;
 }
 .site-title:hover {
-  color: var(--highlight-color-retro);
-  text-shadow: 0 0 8px var(--bg-primary-retro), 0 0 12px var(--bg-primary-retro);
+  color: var(--highlight-color);
 }
 
 /* Navigation Menu */
@@ -80,18 +87,16 @@ html {
   padding: 0;
 }
 .nav-link {
-  color: var(--text-primary);
+  color: var(--text-secondary);
   font-size: 1rem;
   padding: 0.5rem 1rem;
   text-decoration: none;
-  font-weight: bold;
-  text-transform: uppercase;
+  font-weight: 500;
   position: relative;
-  transition: color 0.3s, text-shadow 0.3s;
+  transition: color 0.3s;
 }
 .nav-link:hover {
-  color: var(--highlight-color-retro);
-  text-shadow: 0 0 6px var(--highlight-muted-retro);
+  color: var(--highlight-color);
 }
 
 /* Underline Animation for Links */
@@ -102,7 +107,7 @@ html {
   left: 0;
   width: 100%;
   height: 2px;
-  background-color: var(--highlight-color-retro);
+  background-color: var(--highlight-color);
   opacity: 0;
   transform: scaleX(0);
   transform-origin: center;
@@ -177,7 +182,7 @@ html {
   margin-bottom: 1rem;
   font-size: 2rem;
   padding: 1rem;
-  color: var(--white-1);
+  color: var(--text-primary);
 }
 
 /* Modal Article Links */
@@ -193,7 +198,7 @@ html {
 }
 .modal-article-date {
   font-size: 0.8rem;
-  color: var(--white-1);
+  color: var(--text-secondary);
 }
 .modal-article:hover {
   background: var(--gray-4);

--- a/assets/css/errors.css
+++ b/assets/css/errors.css
@@ -4,9 +4,10 @@
 body.error-page {
   margin: 0;
   padding: 0;
-  background-color: var(--gray-6);
-  color: var(--white-2);
-  font-family: "JetBrains Mono", monospace;
+  background-color: var(--white-1);
+  color: var(--text-primary);
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
   height: 100vh;
   display: flex;
   align-items: center;
@@ -14,16 +15,12 @@ body.error-page {
 }
 
 /* Container styled like .article in post.css */
-.error-container {
-  background: linear-gradient(
-    to bottom,
-    var(--gray-5),
-    var(--gray-4)
-  );    
-  border: 2px solid var(--highlight-color);
+.error-container { 
+  background: var(--white-1);
+  border: 1px solid var(--gray-3);
   padding: 2rem;
-  border-radius: 12px;
-  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.3);
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
   max-width: 95vw;
   width: 600px;
   text-align: center;
@@ -35,11 +32,10 @@ body.error-page {
   font-size: 4rem;
   font-weight: bold;
   margin-bottom: 1rem;
-  text-shadow: 0 0 8px var(--highlight-color);
 }
 
 .error-container h2 {
-  color: var(--white-2);
+  color: var(--text-secondary);
   font-size: 2rem;
   font-weight: bold;
   margin-bottom: 1.5rem;
@@ -50,7 +46,7 @@ body.error-page {
   margin: 0 0 1.75rem;
   font-size: 1.2rem;
   line-height: 1.8;
-  color: var(--white-2);
+  color: var(--text-secondary);
 }
 
 .error-container ul {
@@ -62,7 +58,7 @@ body.error-page {
 .error-container li {
   margin-bottom: 0.75rem;
   font-size: 1.1rem;
-  color: var(--white-2);
+  color: var(--text-secondary);
 }
 
 /* Call‐to‐action button */

--- a/assets/css/landing.css
+++ b/assets/css/landing.css
@@ -1,10 +1,10 @@
 /* General Layout */
 html,
 body {
-  color: var(--white-2);
-  background-color: var(--gray-6);
-  font-family: "JetBrains Mono", monospace;
-  line-height: 1.7;
+  color: var(--text-primary);
+  background-color: var(--white-1);
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  line-height: 1.6;
 }
 
 .landing-page {
@@ -17,7 +17,6 @@ body {
 .landing-page .content-card h1 {
   font-size: 2rem;
   color: var(--text-primary);
-  text-shadow: 0 0 12px var(--highlight-color), 0 0 8px var(--highlight-color);
   text-align: center;
   margin-bottom: 1.5rem;
 }
@@ -30,18 +29,18 @@ body {
 }
 
 .landing-page .articles-card li {
-  background: var(--gray-3);
-  border: 1px solid var(--text-primary);
+  background: var(--white-1);
+  border: 1px solid var(--gray-3);
   padding: 1.5rem;
   border-radius: 8px;
   margin-bottom: 1.5rem;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  transition: transform 0.4s ease, box-shadow 0.4s ease;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+  transition: box-shadow 0.3s ease, transform 0.3s ease;
 }
 
 .landing-page .articles-card li:hover {
   transform: scale(1.02);
-  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 }
 
 .landing-page .articles-card h2 {
@@ -53,12 +52,10 @@ body {
 .landing-page .articles-card h2 a {
   color: inherit;
   text-decoration: none;
-  transition: color 0.3s, text-shadow 0.3s;
 }
 
 .landing-page .articles-card h2 a:hover {
-  color: var(--highlight-color-retro);
-  text-shadow: 0px 0px 8px var(--highlight-muted-retro);
+  color: var(--highlight-color);
 }
 
 .landing-page .articles-card small {
@@ -69,23 +66,23 @@ body {
 .landing-page .articles-card p {
   margin-top: 0.5rem;
   font-size: 1rem;
-  color: var(--white-1);
+  color: var(--text-secondary);
   text-align: justify;
 }
 
 /* Project Section */
 .landing-page .project-card .project-content {
-  background: var(--gray-3);
-  border: 1px solid var(--text-primary);
+  background: var(--white-1);
+  border: 1px solid var(--gray-3);
   padding: 1.5rem;
   border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  transition: transform 0.4s ease, box-shadow 0.4s ease;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+  transition: box-shadow 0.3s ease, transform 0.3s ease;
 }
 
 .landing-page .project-card .project-content:hover {
   transform: scale(1.02);
-  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 }
 
 .landing-page .project-card h2 {
@@ -97,18 +94,16 @@ body {
 .landing-page .project-card h2 a {
   color: inherit;
   text-decoration: none;
-  transition: color 0.3s, text-shadow 0.3s;
 }
 
 .landing-page .project-card h2 a:hover {
-  color: var(--highlight-color-retro);
-  text-shadow: 0px 0px 8px var(--highlight-muted-retro);
+  color: var(--highlight-color);
 }
 
 .landing-page .project-card p {
   margin-top: 0.5rem;
   font-size: 1rem;
-  color: var(--white-1);
+  color: var(--text-secondary);
 }
 
 /* Responsive Design */
@@ -179,10 +174,8 @@ body {
 
 @keyframes glow {
   0% {
-    text-shadow: 0 0 16px var(--highlight-color), 0 0 12px var(--highlight-muted-retro);
   }
   100% {
-    text-shadow: 0 0 40px var(--highlight-color), 0 0 30px var(--highlight-muted-retro);
   }
 }
 

--- a/assets/css/post.css
+++ b/assets/css/post.css
@@ -12,10 +12,10 @@
 /* General Layout */
 html,
 body {
-  color: var(--white-2);
-  background-color: var(--gray-6);
-  font-family: "JetBrains Mono", monospace;
-  line-height: 1.7;
+  color: var(--text-primary);
+  background-color: var(--white-1);
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  line-height: 1.6;
 }
 
 /* Main Content Styling */
@@ -27,17 +27,12 @@ main {
 
 /* Article Section Styling */
 .article {
-  background: linear-gradient(
-    to bottom,
-    var(--gray-5),
-    var(--gray-4)
-  );
-  border: 2px solid var(--highlight-color);
+  background: var(--white-1);
+  border: 1px solid var(--gray-3);
   padding: 2rem;
-  border-radius: 12px;
-  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.3);
+  border-radius: 8px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
   margin-bottom: 2rem;
-  animation: fadeIn 0.6s ease-in-out;
 }
 
 /* Article Title */
@@ -46,9 +41,8 @@ main {
   font-size: 2.6rem;
   text-align: center;
   margin: 0 0 1.5rem;
-  text-shadow: 0 0 8px var(--bg-primary-retro), 0 0 14px var(--highlight-color);
   padding-bottom: 1rem;
-  border-bottom: 2px solid var(--text-secondary);
+  border-bottom: 1px solid var(--gray-3);
 }
 
 /* Article Metadata */
@@ -156,7 +150,6 @@ main {
 .content h6 {
   margin: 1.75rem 0;
   color: var(--text-primary);
-  text-shadow: 0 0 8px var(--highlight-color);
 }
 
 .content ul,
@@ -204,7 +197,6 @@ main {
   text-align: left;
   font-weight: bold;
   border-bottom: 2px solid var(--highlight-color);
-  text-shadow: 0 0 4px var(--highlight-color);
 }
 
 .content tbody tr {

--- a/assets/css/project.css
+++ b/assets/css/project.css
@@ -12,10 +12,10 @@
 /* General Layout */
 html,
 body {
-  color: var(--white-2);
-  background-color: var(--gray-6);
-  font-family: "JetBrains Mono", monospace;
-  line-height: 1.7;
+  color: var(--text-primary);
+  background-color: var(--white-1);
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  line-height: 1.6;
 }
 
 /* Main Content Styling */
@@ -30,7 +30,6 @@ main {
   font-size: 2rem;
   color: var(--text-primary);
   margin-bottom: 1.5rem;
-  text-shadow: 0 0 12px var(--highlight-color), 0 0 8px var(--highlight-color);
   text-align: center;
 }
 
@@ -45,33 +44,18 @@ main {
 }
 
 .projects-section li {
-  margin-bottom: 1.5rem;
-  background: var(--gray-4);
-  border: 1px solid var(--text-primary);
-  padding: 1.5rem;
-  border-radius: 8px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-  transition: transform 0.3s ease, box-shadow 0.3s ease-in-out, background-color 0.3s ease;
+    margin-bottom: 1.5rem;
+    background: var(--white-1);
+    border: 1px solid var(--gray-3);
+    padding: 1.5rem;
+    border-radius: 8px;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+    transition: box-shadow 0.3s ease, transform 0.3s ease;
 }
 
 .projects-section li:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.3);
-  background: linear-gradient(
-    to right,
-    var(--highlight-color-retro),
-    var(--gray-4),
-    var(--gray-4),
-    var(--gray-6),
-    var(--gray-6),
-    var(--gray-6),
-    var(--gray-6),
-    var(--gray-6),
-    var(--gray-6),
-    var(--gray-6),
-    var(--gray-6),
-    var(--gray-6)
-  );
+    transform: translateY(-5px);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 }
 
 .projects-section a {
@@ -79,15 +63,12 @@ main {
   font-size: 1.3rem;
   font-weight: bold;
   text-decoration: none;
-  text-shadow: 0 0 4px var(--text-secondary);
-  transition: color 0.3s, text-shadow 0.3s;
 }
 
 .projects-section a:hover,
 .projects-section a:focus {
-  color: var(--highlight-color-retro);
-  text-shadow: 0 0 8px var(--highlight-color-retro), 0 0 12px var(--highlight-muted-retro);
-  outline: none;
+    color: var(--highlight-color);
+    outline: none;
 }
 
 .projects-section a:focus-visible {
@@ -95,24 +76,19 @@ main {
 }
 
 .projects-section p {
-  color: var(--white-2);
-  font-size: 1rem;
-  margin-top: 0.5rem;
+    color: var(--text-secondary);
+    font-size: 1rem;
+    margin-top: 0.5rem;
 }
 
 /* Project Article Container */
 .project-content {
-  background: linear-gradient(
-    to bottom,
-    var(--gray-5),
-    var(--gray-4)
-  );
-  border: 2px solid var(--highlight-color);
+  background: var(--white-1);
+  border: 1px solid var(--gray-3);
   padding: 2rem;
-  border-radius: 12px;
-  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.3);
+  border-radius: 8px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
   margin: auto;
-  animation: fadeIn 0.6s ease-in-out;
 }
 
 .project-content hr {
@@ -144,9 +120,8 @@ main {
   font-size: 2.6rem;
   text-align: center;
   margin: 0 0 1.5rem;
-  text-shadow: 0 0 8px var(--bg-primary-retro), 0 0 14px var(--highlight-color);
   padding-bottom: 1rem;
-  border-bottom: 2px solid var(--text-secondary);
+  border-bottom: 1px solid var(--gray-3);
 }
 
 /* Project Metadata */
@@ -177,11 +152,11 @@ main {
 }
 
 .project-category {
-  background: var(--gray-3);
+  background: var(--gray-2);
   border-radius: 8px;
   padding: 0.3rem 0.6rem;
   font-size: 0.75rem;
-  color: var(--white-1);
+  color: var(--text-primary);
   transition: background 0.3s, color 0.3s;
   text-transform: uppercase;
 }
@@ -202,7 +177,7 @@ main {
   font-size: 1.4rem;
   text-align: justify;
   margin: 1.5rem 0;
-  color: var(--white-1);
+  color: var(--text-secondary);
   line-height: 1.8;
   padding: 1rem;
 }
@@ -296,7 +271,6 @@ main {
 .project-main-content h6 {
   margin: 1.75rem 0;
   color: var(--text-primary);
-  text-shadow: 0 0 8px var(--highlight-color);
 }
 
 .project-main-content ul,
@@ -344,7 +318,6 @@ main {
   text-align: left;
   font-weight: bold;
   border-bottom: 2px solid var(--highlight-color);
-  text-shadow: 0 0 4px var(--highlight-color);
 }
 
 .project-main-content tbody tr {
@@ -552,7 +525,7 @@ main {
     font-size: 1.2rem;
     text-align: center;
     margin: 1rem 0;
-    color: var(--white-1);
+    color: var(--text-secondary);
     line-height: 1.5;
     padding: 1rem;
   }


### PR DESCRIPTION
## Summary
- Replace retro green-on-black palette with light theme and system fonts
- Restyle blog, post, project, landing and bio pages for cleaner layout
- Simplify header and navigation for better readability

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa28c893a88333b178ee135b638555