### PR TITLE
Modernize site styling

### DIFF
--- a/assets/css/bio.css
+++ b/assets/css/bio.css
@@ -11,9 +11,9 @@
 
 html,
 body {
-  color: var(--white-2);
+  color: var(--text-primary);
   background-color: var(--gray-6);
-  font-family: "JetBrains Mono", monospace;
+  font-family: "Helvetica Neue", Arial, sans-serif;
   line-height: 1.7;
 }
 main {
@@ -26,8 +26,6 @@ main {
   font-size: 2rem;
   color: var(--text-primary);
   margin-bottom: 1.5rem;
-  text-shadow: 0 0 12px var(--highlight-color),
-               0 0 8px var(--highlight-color);
   text-align: center;
 }
 
@@ -59,13 +57,11 @@ main {
   margin-top: 1rem;
   font-size: 1.6rem;
   color: var(--text-primary);
-  text-shadow: 0 0 6px var(--highlight-color);
 }
 .author-quote {
   margin-top: .5rem;
   font-size: 1rem;
   color: var(--text-muted);
-  text-shadow: 0 0 6px var(--highlight-color);
   font-style: italic;
 }
 
@@ -148,7 +144,6 @@ main {
   border:2px solid var(--highlight-color);
   border-radius:9999px;
   box-shadow:0 0 10px rgba(0,0,0,.4), 0 0 8px var(--highlight-color);
-  text-shadow:none;
 }
 
 .timeline{

--- a/assets/css/blog.css
+++ b/assets/css/blog.css
@@ -12,9 +12,9 @@
 /* General Layout */
 html,
 body {
-  color: var(--white-2);
+  color: var(--text-primary);
   background-color: var(--gray-6);
-  font-family: "JetBrains Mono", monospace;
+  font-family: "Helvetica Neue", Arial, sans-serif;
   line-height: 1.7;
 }
 
@@ -72,7 +72,6 @@ img {
   font-size: 2rem;
   color: var(--text-primary);
   margin-bottom: 1.5rem;
-  text-shadow: 0 0 12px var(--highlight-color), 0 0 8px var(--highlight-color);
   text-align: center;
 }
 .articles {
@@ -95,13 +94,11 @@ img {
   font-weight: bold;
   font-size: 1.5rem;
   line-height: 1.3;
-  text-shadow: 0px 0px 4px var(--text-secondary);
   margin-bottom: 0.5rem;
-  transition: color 0.3s, text-shadow 0.3s;
+  transition: color 0.3s;
 }
 .articles .article .article-title:hover {
   color: var(--highlight-color-retro);
-  text-shadow: 0px 0px 8px var(--highlight-muted-retro);
 }
 .article-link {
   color: inherit;
@@ -218,6 +215,5 @@ img {
   }
   .articles .article .article-title {
     font-size: 0.9rem;
-    text-shadow: none;
   }
 }

--- a/assets/css/common.css
+++ b/assets/css/common.css
@@ -1,34 +1,34 @@
 :root {
   /* Grayscale */
-  --gray-1: #3f3f3f;
-  --gray-2: #32353a;
-  --gray-3: #25282c;
-  --gray-4: #151618;
-  --gray-5: #151618;
-  --gray-6: #111111;
+  --gray-1: #f9f9f9;
+  --gray-2: #f0f0f0;
+  --gray-3: #e0e0e0;
+  --gray-4: #d0d0d0;
+  --gray-5: #ffffff;
+  --gray-6: #f5f5f5;
 
-  /* Whites */
-  --white-1: #eeeeee;
-  --white-2: #a9abb3;
+  /* Text Colors */
+  --white-1: #222222;
+  --white-2: #555555;
 
-  /* Highlight and Success */
-  --highlight-color: #348505;
-  --success-color: #348505;
-  --success-muted: #5a8a3c;
+  /* Accent Colors */
+  --highlight-color: #007acc;
+  --success-color: #007acc;
+  --success-muted: #5aa3e6;
 
-  /* Retro Text Colors */
-  --text-primary: #00ff00; /* Bright green for retro titles */
-  --text-secondary: #33cc33; /* Muted green for secondary text */
-  --text-muted: #66ff66; /* Light green for subtle text */
-  --text-inverted: #000000; /* Black text for light backgrounds */
+  /* Standard Text Colors */
+  --text-primary: #222222;
+  --text-secondary: #555555;
+  --text-muted: #777777;
+  --text-inverted: #ffffff;
 
-  /* Retro Highlight Colors */
-  --highlight-color-retro: #ff00ff; /* Magenta for retro highlights */
-  --highlight-muted-retro: #cc00cc; /* Muted magenta for hover states */
+  /* Accent Colors (legacy vars) */
+  --highlight-color-retro: var(--highlight-color);
+  --highlight-muted-retro: #005fa3;
 
-  /* Background Colors for Retro Theme */
-  --bg-primary-retro: #000000; /* Black for retro background */
-  --bg-secondary-retro: #1a1a1a; /* Dark gray for secondary sections */
+  /* Background Colors */
+  --bg-primary-retro: #ffffff;
+  --bg-secondary-retro: #f0f0f0;
 }
 
 /* Smooth in-page scrolling */
@@ -40,10 +40,9 @@ html {
 .site-header {
   background-color: var(--gray-5);
   padding: 1rem 0;
-  margin: 1rem;
-  border-radius: 12px;
-  box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.3);
-  border: 2px solid var(--text-primary);
+  margin: 1rem 0;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .header-container {
@@ -62,12 +61,10 @@ html {
   color: var(--text-primary);
   text-decoration: none;
   font-weight: bold;
-  text-shadow: 0 0 4px var(--text-secondary), 0 0 8px var(--text-secondary);
-  transition: color 0.3s, text-shadow 0.3s;
+  transition: color 0.3s;
 }
 .site-title:hover {
-  color: var(--highlight-color-retro);
-  text-shadow: 0 0 8px var(--bg-primary-retro), 0 0 12px var(--bg-primary-retro);
+  color: var(--highlight-color);
 }
 
 /* Navigation Menu */
@@ -80,18 +77,17 @@ html {
   padding: 0;
 }
 .nav-link {
-  color: var(--text-primary);
+  color: var(--text-secondary);
   font-size: 1rem;
   padding: 0.5rem 1rem;
   text-decoration: none;
-  font-weight: bold;
+  font-weight: 600;
   text-transform: uppercase;
   position: relative;
-  transition: color 0.3s, text-shadow 0.3s;
+  transition: color 0.3s;
 }
 .nav-link:hover {
-  color: var(--highlight-color-retro);
-  text-shadow: 0 0 6px var(--highlight-muted-retro);
+  color: var(--highlight-color);
 }
 
 /* Underline Animation for Links */
@@ -102,7 +98,7 @@ html {
   left: 0;
   width: 100%;
   height: 2px;
-  background-color: var(--highlight-color-retro);
+  background-color: var(--highlight-color);
   opacity: 0;
   transform: scaleX(0);
   transform-origin: center;
@@ -177,14 +173,14 @@ html {
   margin-bottom: 1rem;
   font-size: 2rem;
   padding: 1rem;
-  color: var(--white-1);
+  color: var(--text-primary);
 }
 
 /* Modal Article Links */
 .modal-article,
 .modal-article-date {
   display: block;
-  color: var(--white-2);
+  color: var(--text-secondary);
 }
 .modal-article {
   margin-bottom: 0.5rem;
@@ -193,7 +189,7 @@ html {
 }
 .modal-article-date {
   font-size: 0.8rem;
-  color: var(--white-1);
+  color: var(--text-primary);
 }
 .modal-article:hover {
   background: var(--gray-4);
@@ -202,7 +198,7 @@ html {
 
 /* Horizontal Rule Styling */
 hr {
-  border-top: 2px dashed var(--white-2);
+  border-top: 2px solid var(--gray-3);
   border: none;
   margin-bottom: 1.75rem;
 }

--- a/assets/css/errors.css
+++ b/assets/css/errors.css
@@ -5,8 +5,8 @@ body.error-page {
   margin: 0;
   padding: 0;
   background-color: var(--gray-6);
-  color: var(--white-2);
-  font-family: "JetBrains Mono", monospace;
+  color: var(--text-primary);
+  font-family: "Helvetica Neue", Arial, sans-serif;
   height: 100vh;
   display: flex;
   align-items: center;
@@ -35,7 +35,6 @@ body.error-page {
   font-size: 4rem;
   font-weight: bold;
   margin-bottom: 1rem;
-  text-shadow: 0 0 8px var(--highlight-color);
 }
 
 .error-container h2 {

--- a/assets/css/landing.css
+++ b/assets/css/landing.css
@@ -1,9 +1,9 @@
 /* General Layout */
 html,
 body {
-  color: var(--white-2);
+  color: var(--text-primary);
   background-color: var(--gray-6);
-  font-family: "JetBrains Mono", monospace;
+  font-family: "Helvetica Neue", Arial, sans-serif;
   line-height: 1.7;
 }
 
@@ -17,7 +17,6 @@ body {
 .landing-page .content-card h1 {
   font-size: 2rem;
   color: var(--text-primary);
-  text-shadow: 0 0 12px var(--highlight-color), 0 0 8px var(--highlight-color);
   text-align: center;
   margin-bottom: 1.5rem;
 }
@@ -53,12 +52,11 @@ body {
 .landing-page .articles-card h2 a {
   color: inherit;
   text-decoration: none;
-  transition: color 0.3s, text-shadow 0.3s;
+  transition: color 0.3s;
 }
 
 .landing-page .articles-card h2 a:hover {
   color: var(--highlight-color-retro);
-  text-shadow: 0px 0px 8px var(--highlight-muted-retro);
 }
 
 .landing-page .articles-card small {
@@ -97,12 +95,11 @@ body {
 .landing-page .project-card h2 a {
   color: inherit;
   text-decoration: none;
-  transition: color 0.3s, text-shadow 0.3s;
+  transition: color 0.3s;
 }
 
 .landing-page .project-card h2 a:hover {
   color: var(--highlight-color-retro);
-  text-shadow: 0px 0px 8px var(--highlight-muted-retro);
 }
 
 .landing-page .project-card p {
@@ -179,10 +176,8 @@ body {
 
 @keyframes glow {
   0% {
-    text-shadow: 0 0 16px var(--highlight-color), 0 0 12px var(--highlight-muted-retro);
   }
   100% {
-    text-shadow: 0 0 40px var(--highlight-color), 0 0 30px var(--highlight-muted-retro);
   }
 }
 

--- a/assets/css/post.css
+++ b/assets/css/post.css
@@ -12,9 +12,9 @@
 /* General Layout */
 html,
 body {
-  color: var(--white-2);
+  color: var(--text-primary);
   background-color: var(--gray-6);
-  font-family: "JetBrains Mono", monospace;
+  font-family: "Helvetica Neue", Arial, sans-serif;
   line-height: 1.7;
 }
 
@@ -46,7 +46,6 @@ main {
   font-size: 2.6rem;
   text-align: center;
   margin: 0 0 1.5rem;
-  text-shadow: 0 0 8px var(--bg-primary-retro), 0 0 14px var(--highlight-color);
   padding-bottom: 1rem;
   border-bottom: 2px solid var(--text-secondary);
 }
@@ -156,7 +155,6 @@ main {
 .content h6 {
   margin: 1.75rem 0;
   color: var(--text-primary);
-  text-shadow: 0 0 8px var(--highlight-color);
 }
 
 .content ul,
@@ -204,7 +202,6 @@ main {
   text-align: left;
   font-weight: bold;
   border-bottom: 2px solid var(--highlight-color);
-  text-shadow: 0 0 4px var(--highlight-color);
 }
 
 .content tbody tr {

--- a/assets/css/project.css
+++ b/assets/css/project.css
@@ -12,9 +12,9 @@
 /* General Layout */
 html,
 body {
-  color: var(--white-2);
+  color: var(--text-primary);
   background-color: var(--gray-6);
-  font-family: "JetBrains Mono", monospace;
+  font-family: "Helvetica Neue", Arial, sans-serif;
   line-height: 1.7;
 }
 
@@ -30,7 +30,6 @@ main {
   font-size: 2rem;
   color: var(--text-primary);
   margin-bottom: 1.5rem;
-  text-shadow: 0 0 12px var(--highlight-color), 0 0 8px var(--highlight-color);
   text-align: center;
 }
 
@@ -79,14 +78,12 @@ main {
   font-size: 1.3rem;
   font-weight: bold;
   text-decoration: none;
-  text-shadow: 0 0 4px var(--text-secondary);
-  transition: color 0.3s, text-shadow 0.3s;
+  transition: color 0.3s;
 }
 
 .projects-section a:hover,
 .projects-section a:focus {
   color: var(--highlight-color-retro);
-  text-shadow: 0 0 8px var(--highlight-color-retro), 0 0 12px var(--highlight-muted-retro);
   outline: none;
 }
 
@@ -144,7 +141,6 @@ main {
   font-size: 2.6rem;
   text-align: center;
   margin: 0 0 1.5rem;
-  text-shadow: 0 0 8px var(--bg-primary-retro), 0 0 14px var(--highlight-color);
   padding-bottom: 1rem;
   border-bottom: 2px solid var(--text-secondary);
 }
@@ -296,7 +292,6 @@ main {
 .project-main-content h6 {
   margin: 1.75rem 0;
   color: var(--text-primary);
-  text-shadow: 0 0 8px var(--highlight-color);
 }
 
 .project-main-content ul,
@@ -344,7 +339,6 @@ main {
   text-align: left;
   font-weight: bold;
   border-bottom: 2px solid var(--highlight-color);
-  text-shadow: 0 0 4px var(--highlight-color);
 }
 
 .project-main-content tbody tr {


### PR DESCRIPTION
## Summary
- Replace retro green-on-black palette with light, modern color scheme
- Use clean sans-serif fonts and remove pixelated styling
- Simplify header and navigation for easier reading

## Testing
- `bundle exec jekyll build` *(fails: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68aa28c893a88333b178ee135b638555